### PR TITLE
パスワード入力が非表示になるバグの修正

### DIFF
--- a/app/assets/stylesheets/stylish-portfolio.css
+++ b/app/assets/stylesheets/stylish-portfolio.css
@@ -17,6 +17,10 @@ body {
     src: url(../assets/fonts/uzura.ttf);
 }
 
+input[type=password]{
+    font-family: "";
+}
+
 body {
     font-family: "uzura";
 }


### PR DESCRIPTION
・uzuraフォントだとダメだったのでpasswordのとこだけfontをデフォルトに戻すよう、CSSをいじりました
（神山さんとの合作）